### PR TITLE
Fix build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "devDependencies": {
     "@angular/core": "^2.0.1",
-    "typescript": "^2.0.3"
+    "@types/core-js": "^0.9.34",
+    "typescript": "^2.0.3",
+    "rxjs": "5.0.0-beta.12",
+    "zone.js": "^0.6.12"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
The build had warnings (e.g. run `npm run tsc`), because angular2-masonry was missing @types/core-js, rxjs and zone.js. I added those to devDependencies and everything is now good!
