### PR TITLE
Fix Typescript strict type checking errors

### DIFF
--- a/src/masonry.ts
+++ b/src/masonry.ts
@@ -26,7 +26,7 @@ export class AngularMasonry implements OnInit, OnDestroy {
         private _element: ElementRef
     ) { }
 
-    private _msnry = null;
+    private _msnry: any;
     // private _imagesLoaded = null;
 
     // Inputs
@@ -62,10 +62,10 @@ export class AngularMasonry implements OnInit, OnDestroy {
         // console.log('AngularMasonry:', 'Initialized');
 
         // Bind to events
-        this._msnry.on('layoutComplete', items => {
+        this._msnry.on('layoutComplete', (items: any) => {
             this.layoutComplete.emit(items);
         });
-        this._msnry.on('removeComplete', items => {
+        this._msnry.on('removeComplete', (items: any) => {
             this.removeComplete.emit(items);
         });
     }
@@ -93,7 +93,7 @@ export class AngularMasonry implements OnInit, OnDestroy {
         }
 
         if (this.useImagesLoaded) {
-            imagesLoaded(element, instance => {
+            imagesLoaded(element, (instance: any) => {
                 this._element.nativeElement.appendChild(element);
                 
                 // Tell Masonry that a child element has been added

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "module": "commonjs",
         "target": "es5",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "strictNullChecks": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
First off, thank you for your work in providing this simple, but very useful library.

In our project we are using strict type checking in our Typescript. We are also using this project. We are using angular-cli/webpack to compile our project. With that kind of a setup, there is currently no way to ignore typescript errors/warning from third-party libraries.

This PR resolves issues in this library that allows us to turn on `strictNullChecks` and `noImplicitAny` options in our `tsconfig.json` without getting warnings from this library.
