### PR TITLE
Disable TypeScript strictNullChecks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "experimentalDecorators": true,
         "sourceMap": true,
         "declaration": true,
-        "strictNullChecks": true
+        "strictNullChecks": false
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Apparently Angular 2 has an open bug which prevents using strict null checks (on tsconfig.json).

See Angular bug https://github.com/angular/angular/issues/11844 for details
