### PR TITLE
Added observer when child tree of elements changes - we can triger la…

### DIFF
--- a/src/brick.ts
+++ b/src/brick.ts
@@ -1,3 +1,10 @@
+interface MutationWindow extends Window {
+    MutationObserver: any;
+    WebKitMutationObserver: any;
+}
+
+declare var window: MutationWindow;
+
 import {
     Directive,
     Inject,
@@ -21,9 +28,30 @@ export class AngularMasonryBrick implements OnDestroy, AfterViewInit {
 
     ngAfterViewInit() {
         this._parent.add(this._element.nativeElement);
+        this.watchForHtmlChanges();
     }
 
     ngOnDestroy() {
         this._parent.remove(this._element.nativeElement);
+    }
+
+    /** When HTML in brick changes dinamically, observe that and change layout */
+    private watchForHtmlChanges(): void {
+        MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+        if (MutationObserver) {
+            /** Watch for any changes to subtree */
+            let self = this;
+            let observer = new MutationObserver(function(mutations, observerFromElement) {
+                self._parent.layout();
+            });
+
+            // define what element should be observed by the observer
+            // and what types of mutations trigger the callback
+            observer.observe(this._element.nativeElement, {
+                subtree: true,
+                childList: true
+            });
+        }
     }
 }


### PR DESCRIPTION
This is going to fix issue - https://github.com/jelgblad/angular2-masonry/issues/29.
I used this solution for my local build, so basically, everything is checked and done automatically, we don't have to send EventEmitter events.

Waits for HTML change in one brick and magically calls layout().