### PR TITLE
Add function reloadItems

### DIFF
--- a/src/masonry.ts
+++ b/src/masonry.ts
@@ -83,6 +83,13 @@ export class AngularMasonry implements OnInit, OnDestroy {
 
         // console.log('AngularMasonry:', 'Layout');
     }
+    
+    public reloadItems() {
+      setTimeout(() => {
+        this._msnry.reloadItems();
+        this._msnry.layout();
+      });
+    }
 
     // public add(element: HTMLElement, prepend: boolean = false) {
     public add(element: HTMLElement) {


### PR DESCRIPTION
If the items in a masonry layout change in the DOM (for example because you add/remove/sort items with Angular) provide a way to reload them and trigger a new layout initialization.